### PR TITLE
Add name to report

### DIFF
--- a/app/models/concerns/coordinates_concern.rb
+++ b/app/models/concerns/coordinates_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CoordinatesConcern
+  extend ActiveSupport::Concern
+
+  included do
+    def geo_json_coordinates
+      [longitude, latitude]
+    end
+
+    def geocoder_coordinates
+      [latitude, longitude]
+    end
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -8,6 +8,7 @@
 #  latitude   :float            not null
 #  level      :integer          not null
 #  longitude  :float            not null
+#  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  session_id :string           not null

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -25,7 +25,7 @@ class Report < ApplicationRecord
   MIN_DISTANCE_FROM_LAST_REPORT_IN_TIME = Time.current.beginning_of_day
 
   enum level: {
-    low:      0,
+    clear:    0,
     moderate: 1,
     critical: 2,
   }
@@ -37,7 +37,7 @@ class Report < ApplicationRecord
 
   before_create :reverse_geocode, if: :should_geocode?
 
-  scope :infested, -> { where.not(level: :low) }
+  scope :infested, -> { where.not(level: :clear) }
 
   class << self
     def find_or_initialize_by(attributes)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -19,6 +19,8 @@
 #
 
 class Report < ApplicationRecord
+  include CoordinatesConcern
+
   MIN_DISTANCE_FROM_LAST_REPORT_IN_KM   = 1
   MIN_DISTANCE_FROM_LAST_REPORT_IN_TIME = Time.current.beginning_of_day
 
@@ -63,14 +65,6 @@ class Report < ApplicationRecord
 
     address = results.first.data["address"]
     report.name = address[address.keys.first] if address.present?
-  end
-
-  def geo_json_coordinates
-    [longitude, latitude]
-  end
-
-  def geocoder_coordinates
-    [latitude, longitude]
   end
 
   def numeric_level

--- a/db/migrate/20190821223733_add_name_to_report.rb
+++ b/db/migrate/20190821223733_add_name_to_report.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNameToReport < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reports, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_20_140534) do
+ActiveRecord::Schema.define(version: 2019_08_21_223733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2019_08_20_140534) do
     t.string "session_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
     t.index ["latitude", "longitude"], name: "index_reports_on_latitude_and_longitude"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,10 +40,10 @@ end
 start_time = Time.zone.now
 
 seed_form_file!("2019_beaches_with_sargassum.kml", :infested)
-seed_form_file!("2019_beaches_without_sargassum.kml", :low)
+seed_form_file!("2019_beaches_without_sargassum.kml", :clear)
 
 seed_form_file!("2018_beaches_with_sargassum.kml", :infested)
-seed_form_file!("2018_beaches_without_sargassum.kml", :low)
+seed_form_file!("2018_beaches_without_sargassum.kml", :clear)
 
 elapsed_time = (Time.zone.now - start_time).round
 
@@ -51,6 +51,6 @@ puts " "
 puts "Done in #{elapsed_time} seconds."
 puts ""
 puts "#{Report.count} reports created in #{elapsed_time} seconds".underline
-puts "#{Report.low.count} low reports"
+puts "#{Report.clear.count} clear reports"
 puts "#{Report.moderate.count} moderate reports"
 puts "#{Report.critical.count} critical reports"

--- a/lib/assets/kml/placemark.rb
+++ b/lib/assets/kml/placemark.rb
@@ -6,6 +6,7 @@ module Assets
       InvalidNodeError = Class.new(StandardError)
 
       DATE_REGEX = %r{\d{2}/\d{2}/\d{4}}.freeze
+      NBSP = " "
 
       attr_reader :attributes
 
@@ -16,10 +17,19 @@ module Assets
         @latitude, @longitude, _elevation = parse_coordinates
 
         @attributes = attributes.merge!(
+          name:       formatted_name,
           longitude:  @longitude,
           latitude:   @latitude,
           created_at: @created_at,
         )
+      end
+
+      def formatted_name
+        @name.gsub(DATE_REGEX, "")
+             .tr(NBSP, "")
+             .split("-")
+             .first
+             .strip
       end
 
       private

--- a/test/decorators/reports_decorator_test.rb
+++ b/test/decorators/reports_decorator_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ReportsDecoratorTest < Draper::TestCase
   test "should format collection as a valid geoJSON" do
-    create_list(:report, 10, :low)
+    create_list(:report, 10, :clear)
     create_list(:report, 10, :moderate)
     create_list(:report, 10, :critical)
 

--- a/test/factories/reports.rb
+++ b/test/factories/reports.rb
@@ -8,6 +8,7 @@
 #  latitude   :float            not null
 #  level      :integer          not null
 #  longitude  :float            not null
+#  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  session_id :string           not null
@@ -19,6 +20,7 @@
 
 FactoryBot.define do
   factory :report do
+    name { Faker::Address.street_name }
     latitude { Faker::Address.latitude }
     longitude { Faker::Address.longitude }
     level { :critical }
@@ -37,6 +39,7 @@ FactoryBot.define do
     end
 
     trait :sugiton do
+      name { "Calanque de Sugiton" }
       latitude { 43.217595 }
       longitude { 5.4557003 }
     end

--- a/test/factories/reports.rb
+++ b/test/factories/reports.rb
@@ -26,8 +26,8 @@ FactoryBot.define do
     level { :critical }
     session_id { SecureRandom.hex }
 
-    trait :low do
-      level  { :low }
+    trait :clear do
+      level  { :clear }
     end
 
     trait :moderate do

--- a/test/lib/assets/kml/placemark_test.rb
+++ b/test/lib/assets/kml/placemark_test.rb
@@ -8,9 +8,17 @@ class Assets::KML::PlacemarkTest < ActiveSupport::TestCase
     placemark = Assets::KML::Placemark.new(node)
 
     assert_kind_of Hash, placemark.attributes
+    assert_kind_of String, placemark.attributes[:name]
     assert_kind_of DateTime, placemark.attributes[:created_at]
     assert_kind_of Float, placemark.attributes[:latitude]
     assert_kind_of Float, placemark.attributes[:longitude]
+  end
+
+  test "should cleanup name and remove dates from it" do
+    node = Nokogiri::XML(valid_kml).css("Placemark")
+    placemark = Assets::KML::Placemark.new(node)
+
+    assert_equal "Anses d'Arlet", placemark.attributes[:name]
   end
 
   private
@@ -18,7 +26,7 @@ class Assets::KML::PlacemarkTest < ActiveSupport::TestCase
   def valid_kml
     <<~KML
       <Placemark>
-        <name>01/01/2019 Anses d'Arlet - Martinique></name>
+        <name>01/01/2019 Anses d'Arlet - Martinique </name>
         <Point>
           <coordinates>
             -61.0841083,14.4986926,0

--- a/test/lib/assets/kml_test.rb
+++ b/test/lib/assets/kml_test.rb
@@ -26,6 +26,7 @@ class Assets::KMLTest < ActiveSupport::TestCase
 
     assert_equal custom_attributes[:level], kml.placemarks.first[:level]
     assert_equal custom_attributes[:session_id], kml.placemarks.first[:session_id]
+    assert kml.placemarks.first[:name].present?
     assert kml.placemarks.first[:created_at].present?
     assert kml.placemarks.first[:latitude].present?
     assert kml.placemarks.first[:longitude].present?

--- a/test/lib/assets/kml_test.rb
+++ b/test/lib/assets/kml_test.rb
@@ -15,7 +15,7 @@ class Assets::KMLTest < ActiveSupport::TestCase
 
   test "should accept custom placemark attributes" do
     custom_attributes = {
-      level:      :low,
+      level:      :clear,
       session_id: SecureRandom.hex,
     }
 

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -22,10 +22,10 @@ require "test_helper"
 
 class ReportTest < ActiveSupport::TestCase
   test "should be valid" do
-    low = Report.new(
+    clear = Report.new(
       latitude:   Faker::Address.latitude,
       longitude:  Faker::Address.longitude,
-      level:      :low,
+      level:      :clear,
       session_id: SecureRandom.hex,
     )
     moderate = Report.new(
@@ -41,7 +41,7 @@ class ReportTest < ActiveSupport::TestCase
       session_id: SecureRandom.hex,
     )
 
-    assert low.valid?
+    assert clear.valid?
     assert moderate.valid?
     assert critical.valid?
   end
@@ -58,14 +58,14 @@ class ReportTest < ActiveSupport::TestCase
   end
 
   test "should only return infested reports" do
-    create_list(:report, 2, :low)
+    create_list(:report, 2, :clear)
     create_list(:report, 2, :moderate)
     create_list(:report, 2, :critical)
 
     reports = Report.infested
 
     assert_equal 4, reports.size
-    assert_not reports.any?(&:low?)
+    assert_not reports.any?(&:clear?)
   end
 
   test "should return a valid geoJSON coordinates array" do
@@ -124,7 +124,7 @@ class ReportTest < ActiveSupport::TestCase
       longitude:  coords[:longitude],
       latitude:   coords[:latitude],
       session_id: report.session_id,
-      level:      :low,
+      level:      :clear,
     )
 
     assert_equal report, result
@@ -139,7 +139,7 @@ class ReportTest < ActiveSupport::TestCase
       longitude:  coords[:longitude],
       latitude:   coords[:latitude],
       session_id: report.session_id,
-      level:      :low,
+      level:      :clear,
     )
 
     assert result.new_record?

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -88,11 +88,19 @@ class ReportTest < ActiveSupport::TestCase
     assert_kind_of Integer, report.numeric_level
   end
 
-  test "should be geocoded" do
-    create(:report)
+  test "should not be geocoded" do
+    report = build(:report)
+    init_name = report.name
 
-    assert_not_empty Report.geocoded
-    assert_empty Report.not_geocoded
+    assert report.save
+    assert_equal init_name, report.name, "FACTORIES SHOULD NOT TRIGGER GEOCODER".light_red
+  end
+
+  test "should be reverse geocoded with most accurate place name" do
+    report = build(:report, :sugiton, name: nil)
+
+    assert report.save
+    assert_equal "Sentier des Treize Contours", report.name
   end
 
   test "should filter reports in a given km perimeter" do

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -8,6 +8,7 @@
 #  latitude   :float            not null
 #  level      :integer          not null
 #  longitude  :float            not null
+#  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  session_id :string           not null


### PR DESCRIPTION
Report name is handled by model with geocoding. 

I only take the most precise result from reverse geocoding hoping for a beach or place name, not an exact address. If not a beach or place it will be a street name, at worst a region or a country. 