### PR TITLE
Strengthen user identification

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -7,9 +7,9 @@ Pry.config.color = true
 # report = _
 Pry::Commands.block_command "sugiton", "Returns a new report instance at Sugiton", keep_retval: true do
   Report.new(
-    level:      :clear,
-    latitude:   43.210479,
-    longitude:  5.4468282,
-    session_id: SecureRandom.hex,
+    level:     :clear,
+    latitude:  43.210479,
+    longitude: 5.4468282,
+    user_id:   SecureRandom.hex,
   )
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :init_session
+  before_action :authenticate_user
 
-  # Sessions are lazily loaded.
-  # If we don't access sessions in our action's code, they will not be loaded.
-  # See https://github.com/rails/rails/issues/10813
-  #
-  def init_session
-    session.delete "init"
+  private
+
+  def authenticate_user
+    return if user_id
+
+    @user_id = cookies[:user_id] = request.headers["HTTP_X_FINGERPRINT"]
+  end
+
+  def user_id
+    @user_id ||= cookies[:user_id]
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReportsController < ApplicationController
+  skip_before_action :authenticate_user, only: :index
+
   def index
     render json: Report.cached_geo_json
   end
@@ -21,6 +23,6 @@ class ReportsController < ApplicationController
   def report_params
     params.require(:report)
           .permit(:latitude, :longitude, :level)
-          .merge(session_id: session.id)
+          .merge(user_id: user_id)
   end
 end

--- a/app/javascript/components/BigChart.jsx
+++ b/app/javascript/components/BigChart.jsx
@@ -21,6 +21,8 @@ import {
   getTickFormatter,
 } from '../utils/interval';
 
+const { levels } = gon;
+
 const propTypes = {
   data,
   interval,
@@ -62,14 +64,14 @@ const BigChart = ({ data, interval }) => {
             content={<ChartTooltip unit={interval.unit} />}
           />
           <Legend iconType="circle" />
-          {['clear', 'moderate', 'critical'].map(humanLevel => (
+          {levels.map(({ label }) => (
             <Area
-              key={humanLevel}
+              key={label}
               type="linear"
-              dataKey={humanLevel}
+              dataKey={label}
               stackId="1"
-              stroke={theme.palette.level[humanLevel].main}
-              fill={theme.palette.level[humanLevel].main}
+              stroke={theme.palette.level[label].main}
+              fill={theme.palette.level[label].main}
             />
           ))}
         </AreaChart>

--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -248,7 +248,7 @@ class Map extends PureComponent {
       popup.variant = 'report';
       popup.onSubmit = this.onReportSubmit;
     } else {
-      popup.text = 'Please get closer to the beach';
+      popup.text = 'Please get closer to the beach 🏝️';
     }
 
     this.setState({

--- a/app/javascript/components/TinyChart.jsx
+++ b/app/javascript/components/TinyChart.jsx
@@ -6,6 +6,8 @@ import { makeStyles } from '@material-ui/styles';
 
 import { data } from '../utils/propTypes';
 
+const { levels } = gon;
+
 const propTypes = {
   data,
 };
@@ -36,14 +38,14 @@ const TinyChart = ({ data, ...containerProps }) => {
     <ResponsiveContainer {...containerProps}>
       <AreaChart data={data} margin={{ top: 0, left: 0, right: 0, bottom: 0 }}>
         <YAxis domain={[0, 'dataMax']} hide />
-        {['clear', 'moderate', 'critical'].map(humanLevel => (
+        {levels.map(({ label }) => (
           <Area
-            key={humanLevel}
+            key={label}
             type="linear"
-            dataKey={humanLevel}
+            dataKey={label}
             stackId="1"
-            stroke={theme.palette.level[humanLevel].main}
-            fill={theme.palette.level[humanLevel].main}
+            stroke={theme.palette.level[label].main}
+            fill={theme.palette.level[label].main}
           />
         ))}
       </AreaChart>

--- a/app/javascript/utils/Api.js
+++ b/app/javascript/utils/Api.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
 
-const accept = 'application/json';
+import csrfToken from './csrfToken';
+import Fingerprint from '../utils/Fingerprint';
 
-const getToken = () => document.querySelector('meta[name=csrf-token]').content;
-const csrfHeader = () => ({ headers: { 'X-CSRF-Token': getToken() } });
+const fingerprint = new Fingerprint();
+const accept = 'application/json';
 
 export default class {
   constructor() {
@@ -14,11 +15,20 @@ export default class {
     axios.default.headers = { accept };
   }
 
+  _postHeaders() {
+    return {
+      headers: {
+        'X-CSRF-Token': csrfToken(),
+        'X-Fingerprint': fingerprint.hash,
+      },
+    };
+  }
+
   getAll() {
     return axios.get('/reports');
   }
 
   create(report) {
-    return axios.post('/reports', { report }, csrfHeader());
+    return axios.post('/reports', { report }, this._postHeaders());
   }
 }

--- a/app/javascript/utils/Fingerprint.js
+++ b/app/javascript/utils/Fingerprint.js
@@ -1,0 +1,28 @@
+// Note: You should not run fingerprinting directly on or after page load.
+// Rather, delay it for a few milliseconds with setTimeout or requestIdleCallback
+// to ensure consistent fingerprints.
+//
+// https://github.com/Valve/fingerprintjs2#usage
+
+import Fingerprint2 from 'fingerprintjs2';
+
+export default class {
+  constructor() {
+    this.hash = null;
+
+    this._init();
+  }
+
+  _setHash = () =>
+    Fingerprint2.getV18(result => {
+      this.hash = result;
+    });
+
+  _init() {
+    if (window.requestIdleCallback) {
+      requestIdleCallback(this._setHash);
+    } else {
+      setTimeout(this._setHash, 500);
+    }
+  }
+}

--- a/app/javascript/utils/csrfToken.js
+++ b/app/javascript/utils/csrfToken.js
@@ -1,0 +1,1 @@
+export default () => document.querySelector('meta[name=csrf-token]').content;

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,7 +11,7 @@
 #  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  session_id :string           not null
+#  user_id    :string           not null
 #
 # Indexes
 #
@@ -36,7 +36,7 @@ class Report < ApplicationRecord
   validates :latitude, numericality: LATITUDE_NUMERICALITY
   validates :longitude, numericality: LONGITUDE_NUMERICALITY
   validates :level, presence: true
-  validates :session_id, presence: true
+  validates :user_id, presence: true, length: { is: 32 }
 
   before_create :reverse_geocode, if: :should_geocode?
 
@@ -70,10 +70,10 @@ class Report < ApplicationRecord
     end
 
     def current_with(params)
-      session_id, latitude, longitude = params.values_at(:session_id, :latitude, :longitude)
+      user_id, latitude, longitude = params.values_at(:user_id, :latitude, :longitude)
 
       where(
-        session_id: session_id,
+        user_id:    user_id,
         created_at: MIN_DISTANCE_FROM_LAST_REPORT_IN_TIME..,
       )
         .near([latitude, longitude], MIN_DISTANCE_FROM_LAST_REPORT_IN_KM, units: :km)

--- a/db/migrate/20190820113527_create_reports.rb
+++ b/db/migrate/20190820113527_create_reports.rb
@@ -3,12 +3,15 @@
 class CreateReports < ActiveRecord::Migration[6.0]
   def change
     create_table :reports do |t|
+      t.string :name
       t.float :latitude, null: false
       t.float :longitude, null: false
       t.integer :level, null: false
-      t.string :session_id, null: false
+      t.string :user_id, null: false
 
       t.timestamps
+
+      t.index [:latitude, :longitude]
     end
   end
 end

--- a/db/migrate/20190820140534_add_cordinates_index_to_reports.rb
+++ b/db/migrate/20190820140534_add_cordinates_index_to_reports.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddCordinatesIndexToReports < ActiveRecord::Migration[6.0]
-  def change
-    add_index :reports, [:latitude, :longitude]
-  end
-end

--- a/db/migrate/20190821223733_add_name_to_report.rb
+++ b/db/migrate/20190821223733_add_name_to_report.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddNameToReport < ActiveRecord::Migration[6.0]
-  def change
-    add_column :reports, :name, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_21_223733) do
+ActiveRecord::Schema.define(version: 2019_08_20_113527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "reports", force: :cascade do |t|
+    t.string "name"
     t.float "latitude", null: false
     t.float "longitude", null: false
     t.integer "level", null: false
-    t.string "session_id", null: false
+    t.string "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "name"
     t.index ["latitude", "longitude"], name: "index_reports_on_latitude_and_longitude"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,8 +24,8 @@ end
 def seed_form_file!(file_name, level)
   file_path = Rails.root.join("db", "data", file_name)
   attributes = {
-    level:      level,
-    session_id: file_path.basename.to_s,
+    level:   level,
+    user_id: SecureRandom.hex,
   }
 
   kml = Assets::KML.new(file_path, attributes)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "cheap-ruler": "^2.5.1",
     "clsx": "^1.0.4",
+    "fingerprintjs2": "^2.1.0",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",

--- a/test/factories/reports.rb
+++ b/test/factories/reports.rb
@@ -11,7 +11,7 @@
 #  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  session_id :string           not null
+#  user_id    :string           not null
 #
 # Indexes
 #
@@ -24,7 +24,7 @@ FactoryBot.define do
     latitude { Faker::Address.latitude }
     longitude { Faker::Address.longitude }
     level { :critical }
-    session_id { SecureRandom.hex }
+    user_id { SecureRandom.hex }
 
     trait :clear do
       level  { :clear }

--- a/test/lib/assets/kml_test.rb
+++ b/test/lib/assets/kml_test.rb
@@ -15,8 +15,8 @@ class Assets::KMLTest < ActiveSupport::TestCase
 
   test "should merge custom placemark attributes" do
     custom_attributes = {
-      level:      :clear,
-      session_id: SecureRandom.hex,
+      level:   :clear,
+      user_id: SecureRandom.hex,
     }
 
     kml = Assets::KML.new(
@@ -28,14 +28,14 @@ class Assets::KMLTest < ActiveSupport::TestCase
     last = kml.placemarks.last
 
     assert_equal custom_attributes[:level], first[:level]
-    assert_equal custom_attributes[:session_id], first[:session_id]
+    assert_equal custom_attributes[:user_id], first[:user_id]
     assert first[:name].present?
     assert first[:updated_at].present?
     assert first[:latitude].present?
     assert first[:longitude].present?
 
     assert_equal custom_attributes[:level], first[:level]
-    assert_equal custom_attributes[:session_id], first[:session_id]
+    assert_equal custom_attributes[:user_id], first[:user_id]
 
     assert_not_equal first[:name], last[:name]
     assert_not_equal first[:latitude], last[:latitude]

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -11,7 +11,7 @@
 #  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  session_id :string           not null
+#  user_id    :string           not null
 #
 # Indexes
 #
@@ -23,22 +23,22 @@ require "test_helper"
 class ReportTest < ActiveSupport::TestCase
   test "should be valid" do
     clear = Report.new(
-      latitude:   Faker::Address.latitude,
-      longitude:  Faker::Address.longitude,
-      level:      :clear,
-      session_id: SecureRandom.hex,
+      latitude:  Faker::Address.latitude,
+      longitude: Faker::Address.longitude,
+      level:     :clear,
+      user_id:   SecureRandom.hex,
     )
     moderate = Report.new(
-      latitude:   Faker::Address.latitude,
-      longitude:  Faker::Address.longitude,
-      level:      :moderate,
-      session_id: SecureRandom.hex,
+      latitude:  Faker::Address.latitude,
+      longitude: Faker::Address.longitude,
+      level:     :moderate,
+      user_id:   SecureRandom.hex,
     )
     critical = Report.new(
-      latitude:   Faker::Address.latitude,
-      longitude:  Faker::Address.longitude,
-      level:      :critical,
-      session_id: SecureRandom.hex,
+      latitude:  Faker::Address.latitude,
+      longitude: Faker::Address.longitude,
+      level:     :critical,
+      user_id:   SecureRandom.hex,
     )
 
     assert clear.valid?
@@ -53,7 +53,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_includes map_errors(report, :latitude), :not_a_number
     assert_includes map_errors(report, :longitude), :not_a_number
     assert_includes map_errors(report, :level), :blank
-    assert_includes map_errors(report, :session_id), :blank
+    assert_includes map_errors(report, :user_id), :blank
 
     report.latitude = 180
     report.longitude = -200
@@ -136,10 +136,10 @@ class ReportTest < ActiveSupport::TestCase
     report = create(:report, :sugiton, :critical)
     coords = coordinates_hash(:sugiton_beach)
     params = report_params(
-      longitude:  coords[:longitude],
-      latitude:   coords[:latitude],
-      session_id: report.session_id,
-      level:      "clear",
+      longitude: coords[:longitude],
+      latitude:  coords[:latitude],
+      user_id:   report.user_id,
+      level:     "clear",
     )
 
     result = Report.find_or_initialize_by(params)
@@ -152,10 +152,10 @@ class ReportTest < ActiveSupport::TestCase
     report = create(:report, :sugiton, :critical)
     coords = coordinates_hash(:morgiou)
     params = report_params(
-      longitude:  coords[:longitude],
-      latitude:   coords[:latitude],
-      session_id: report.session_id,
-      level:      :clear,
+      longitude: coords[:longitude],
+      latitude:  coords[:latitude],
+      user_id:   report.user_id,
+      level:     :clear,
     )
 
     result = Report.find_or_initialize_by(params)
@@ -227,7 +227,7 @@ class ReportTest < ActiveSupport::TestCase
   def report_params(attributes)
     ActionController::Parameters
       .new(report: attributes)
-      .require(:report).permit(:level, :longitude, :latitude, :session_id)
+      .require(:report).permit(:level, :longitude, :latitude, :user_id)
   end
 
   def map_errors(record, attribute)

--- a/test/test_headers_helper.rb
+++ b/test/test_headers_helper.rb
@@ -14,4 +14,10 @@ module TestHeadersHelper
       # "Content-Type" => "json",
     }
   end
+
+  def auth_headers
+    json_headers.merge(
+      "X-Fingerprint" => SecureRandom.hex,
+    )
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,6 +3653,11 @@ findup-sync@3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+fingerprintjs2@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fingerprintjs2/-/fingerprintjs2-2.1.0.tgz#21dc3fee27d3b199056ef8eb873debccd8e06323"
+  integrity sha512-H1k/ESTD2rJ3liupyqWBPjZC+LKfCGixQzz/NDN4dkgbmG1bVFyMOh7luKSkVDoyfhgvRm62pviNMPI+eJTZcQ==
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"


### PR DESCRIPTION
Fingerprint user browser, store it in cookies and use it as `Report#user_id`: 
- cookies has longer life than sessions 
- fingerprinting prevents user navigating incognito to create multiple reports at the same place